### PR TITLE
Add design spec template and sidebar UX spec draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # Ignore these dotfiles/dotdirs
 .DS_Store
+.claude/
 .devcontainer/.claude/
 .devcontainer/.library/
 .devcontainer/.env

--- a/design/TEMPLATE.md
+++ b/design/TEMPLATE.md
@@ -1,0 +1,52 @@
+# Design Spec Template
+
+Each feature gets its own directory under `design/{feature}/`.
+Features often span multiple packages, so specs are organized by feature, not package.
+Once a feature is implemented and merged, its spec moves to `design/archive/`.
+
+## Directory structure
+
+```
+design/
+  {feature}/
+    overview.md        # Summary, motivation, key decisions, open questions
+    ux.md              # Interaction flow, visual states, transitions (product/UX spec)
+    architecture.md    # Technical design, S3 generics, file structure, API (technical spec)
+    img/               # Screenshots, mockups, diagrams
+    examples/          # Example code snippets, demo apps
+  archive/             # Completed features (moved here after merge)
+```
+
+Not every feature needs all files. A small feature might just have `overview.md`.
+A complex feature might have all of them plus additional files as needed.
+
+## Spec types
+
+### Product / UX Spec (`overview.md` + `ux.md`)
+
+Written by the product owner. This is the primary review artifact -- the team
+reviews the spec, not the code.
+
+**overview.md** should contain:
+1. **Summary** -- One paragraph: what the feature does and why it exists
+2. **Prototype** -- Link to deployed app on blockr.cloud or branch name
+3. **Key Decisions** -- Choices made and their rationale
+4. **Open Questions** -- Unresolved items for spec review
+
+**ux.md** should contain:
+1. **Interaction Flow** -- Step-by-step: what the user does and what happens
+2. **Visual States** -- What each state looks like (with screenshots from `img/`)
+3. **Transitions** -- How the UI moves between states
+4. **Edge Cases** -- Empty states, error states, loading states
+
+### Technical Spec (`architecture.md`)
+
+Written by the architect. Follows the pattern established in `design/core/roclet.md`:
+problem, solution, API design, file structure, implementation notes, verification plan.
+
+## Conventions
+
+- One directory per feature: `design/{feature}/`
+- Images go in `img/` subdirectory
+- Spec is approved before implementation begins
+- After implementation is merged, move spec to `design/archive/{feature}/`

--- a/design/sidebar/architecture.md
+++ b/design/sidebar/architecture.md
@@ -1,0 +1,55 @@
+# Sidebar -- Architecture
+
+## S3 Generic
+
+```r
+sidebar_content_ui <- function(type, ...) {
+  UseMethod("sidebar_content_ui")
+}
+```
+
+Each content type (e.g., `"add_block"`, `"create_link"`, `"settings"`) is a class,
+and `sidebar_content_ui()` dispatches to the appropriate method. This gives us 9
+content type methods in the prototype.
+
+## File Structure
+
+```
+R/
+  sidebar-api.R        # Public API: show_sidebar(), hide_sidebar(), sidebar_content_ui() generic
+  sidebar-ui.R         # Sidebar UI container (the panel itself)
+  sidebar-content.R    # S3 methods for each content type
+  sidebar-server.R     # Sidebar server logic, event handling
+
+inst/
+  assets/
+    js/
+      blockr-sidebar.js   # JS module: slide animation, keyboard nav, search debounce
+```
+
+## Impact on Existing Code
+
+Each action file (add-block, create-link, manage-stacks, etc.) currently contains
+modal dialog logic. With the sidebar, each reduces to a `show_sidebar(type, ...)` call.
+The prototype shows ~70% reduction in action file code.
+
+## Extension Pattern
+
+Any package can add a new sidebar content type:
+
+```r
+# In blockr.mypackage:
+sidebar_content_ui.my_custom_type <- function(type, ...) {
+  # return shiny UI
+}
+```
+
+No registration needed -- S3 dispatch handles discovery automatically.
+
+## Data Flow
+
+1. User action triggers `show_sidebar(type = "add_block", context = list(...))`
+2. `show_sidebar()` stores context in `session$userData$sidebar_context`
+3. `sidebar_content_ui()` dispatches on `type` class to render the right UI
+4. Content-specific server logic reads context from `session$userData`
+5. On completion, content calls `hide_sidebar()` and triggers the actual operation

--- a/design/sidebar/overview.md
+++ b/design/sidebar/overview.md
@@ -1,0 +1,32 @@
+# Sidebar
+
+## Summary
+
+Replace all modal dialogs in blockr.dock with a unified slide-out sidebar. Every
+board action (add block, create link, manage stacks, settings) opens the same
+sidebar panel instead of a modal. The sidebar uses S3 dispatch so extension packages
+can add new sidebar content types without modifying blockr.dock.
+
+## Prototype
+
+Branch: `blockr.dock@feat/sidebar-s3-dispatch`
+
+## Key Decisions
+
+- **Single sidebar, not multiple.** One sidebar panel that swaps content depending
+  on the action. Simpler mental model for users, simpler code.
+- **S3 dispatch for content types.** `sidebar_content_ui()` is an S3 generic.
+  Each content type (add-block, create-link, settings, ...) is a method. Extension
+  packages just add methods.
+- **Context via `session$userData`.** Sidebar content methods receive context (which
+  stack, which block, etc.) through `session$userData`, not through function
+  arguments. Keeps the generic signature simple.
+- **No overlay.** The sidebar slides in from the left but does not dim or block the
+  dock panels behind it. Users can still see their board while the sidebar is open.
+
+## Open Questions
+
+- Should sidebar width be responsive (narrower on small screens)?
+- Should there be transition animations when switching content types within an
+  already-open sidebar?
+- How should keyboard focus be managed when sidebar opens/closes?

--- a/design/sidebar/ux.md
+++ b/design/sidebar/ux.md
@@ -1,0 +1,59 @@
+# Sidebar -- UX
+
+## Interaction Flow
+
+1. User clicks a board action button (e.g., "Add Block" in toolbar)
+2. Sidebar slides in from the left edge (~380px wide)
+3. Sidebar header shows the action name and a close button
+4. Content area displays the appropriate UI for that action
+5. User completes the action (e.g., selects a block) or presses Escape / clicks close
+6. Sidebar slides out; dock returns to full width
+
+If the sidebar is already open and the user clicks a different action, the content
+swaps in place without closing and reopening.
+
+## Content Layout (Add Block example)
+
+- **Search input** at top, auto-focused on open, 150ms debounce
+- **Card-based selection** below search:
+  - Each card shows: icon, block name, description, package badge
+  - Cards grouped by category (Input, Transform, Plot, ...)
+  - Category headers are collapsible
+- **Accordion** at bottom for optional fields:
+  - Custom block name
+  - Custom block ID
+  - Input selection (which block to connect to)
+- **Sticky footer** with action buttons (e.g., "Add", "Cancel")
+
+## Keyboard Navigation
+
+- **Arrow Up / Down** -- move between cards
+- **Enter** -- select the highlighted card
+- **Escape** -- close sidebar
+- **Tab** -- move between search, cards, accordion, footer
+
+## Visual States
+
+### Sidebar closed
+Standard dock view, full width.
+
+### Sidebar open
+Dock panels shift right (or shrink) by ~380px. Sidebar is flush with the left edge.
+No overlay or dimming.
+
+`[TODO: screenshot from prototype -- img/sidebar-open.png]`
+
+### Search filtering
+Cards filter in real-time as user types. Categories with no matches collapse.
+
+`[TODO: screenshot -- img/sidebar-search.png]`
+
+### Empty state
+When search returns no results: centered message "No blocks found" with suggestion
+to clear the search.
+
+## Transitions
+
+- Sidebar open/close: CSS slide transition (~200ms ease-out)
+- Content swap: crossfade (~150ms) when switching between action types
+- Card filtering: immediate (no animation), but categories collapse smoothly


### PR DESCRIPTION
## Summary

- Adds `design/TEMPLATE.md` defining a directory-per-feature spec structure (`design/{feature}/` with `overview.md`, `ux.md`, `architecture.md`, `img/`, `examples/`)
- Adds first draft sidebar spec (`design/sidebar/`) based on the `blockr.dock@feat/sidebar-s3-dispatch` prototype
- Gitignores `.claude/` so each developer can have personal Claude Code config

## Spec-review workflow

The idea: shift from **code review to spec review**. The product owner writes UX specs (overview + interaction flow), the architect writes technical specs. The team reviews and iterates on the spec. Only after approval does implementation begin. This is cheaper than iterating on code.

The sidebar feature is the first test case -- the prototype exists on a branch but the code isn't clean enough for direct merge. Instead: review the spec, then implement clean.

## Discussion point: AGENTS.md vs CLAUDE.md

Claude Code auto-reads `CLAUDE.md` but **not** `AGENTS.md`. Since the whole team uses Claude Code, it might make sense to rename `AGENTS.md` to `CLAUDE.md` (or symlink). This is a team decision -- @DColumn @nicColumn what do you think?

## TODO

- [ ] Add screenshots from running sidebar prototype to `design/sidebar/img/`
- [ ] Review and iterate on sidebar spec content
- [ ] Decide on AGENTS.md vs CLAUDE.md naming